### PR TITLE
Clean up white space in pld source files

### DIFF
--- a/source/u202.pld
+++ b/source/u202.pld
@@ -72,8 +72,8 @@ field addr 	= [A6..A1];
 /* The board configuration is really quite simple.  If there's a
    write to the configuration register space, the configuration address
    is latched and we pass configuration out.  If the system is shunted
-   (eg, in a Zorro II backplane), configuration out goes immediately. 
-   Note that the configuration read registers are actually supplied by 
+   (eg, in a Zorro II backplane), configuration out goes immediately.
+   Note that the configuration read registers are actually supplied by
    the first part of the boot ROM. */
 
 CFGLT		= addr:44 & dataspace & FCS & !READ & CFGIN & DS3 & !BERR & !RST
@@ -84,7 +84,7 @@ CFGOUT		= CFGLT & !RST & !FCS
 		# SHUNT;
 
 /* The slave signal is drive from here for any normal access.  When it isn't
-   being driven, it is tri-stated, since the interrupt response logic may 
+   being driven, it is tri-stated, since the interrupt response logic may
    also drive SLAVE.  */
 
 SLAVEOE		= CFGIN & MATCH & dataspace & FCS & !RST;

--- a/source/u203.pld
+++ b/source/u203.pld
@@ -95,7 +95,7 @@ intcyc		= INTSPC & FC2 & A19 & A18 & A17 & !A1 & READ;
    880000	INTREG
    840000	SCSI write
    800000	SCSI read
-   000000	ROM   
+   000000	ROM
 
 */
 
@@ -112,7 +112,7 @@ ROM		= cpucyc & SLAVE & READ & addr:[7fffff..000000]
 
 SCSI		= cpucyc & SLAVE & addr:[87ffff..800000];
 
-/* The interrupt register select is actually a latching signal.  It should be 
+/* The interrupt register select is actually a latching signal.  It should be
    asserted in interrupt register space only after data is valid, and only on
    writes. */
 
@@ -148,7 +148,7 @@ INTSERV		= intcyc & INT & INTASS & !FCS
 INTPOLL		= INTSERV & MTCR
 		# INTPOLL & FCS;
 
-/* A slave output is generated if we're established that the polling phase is 
+/* A slave output is generated if we're established that the polling phase is
    being answered. */
 
 SLAVE		= 'b'1;

--- a/source/u205.pld
+++ b/source/u205.pld
@@ -70,7 +70,7 @@ PIN 17		= !DTACK	;	/* Zorro III termination. */
 
 /** LOGICAL TERMS: **/
 
-/* It takes both MYBUS and MASTER to fully qualify a cycle.  If MYBUS is 
+/* It takes both MYBUS and MASTER to fully qualify a cycle.  If MYBUS is
    asserted but master not, we're in the process of bus arbitration.  If
    MASTER is asserted but not MYBUS, the SCSI chip is master of the A4091
    bus and waiting for a grant to the Zorro bus.  In both of these cases,
@@ -85,13 +85,13 @@ slavecyc	= !MYBUS & !MASTER;
 /* This is the data output enable control.  When data buffers are
    pointed toward the board, they can turn on early in the cycle.
    This is a write for slave access, a read for DMA access.  When
-   the data buffers are pointed out toward the bus, the have to 
-   wait until DOE to turn on; this is a slave read or DMA write. 
+   the data buffers are pointed out toward the bus, the have to
+   wait until DOE to turn on; this is a slave read or DMA write.
    When the board responds to itself, the buffers are left off.   If
-   the NOZ3 signal is asserted on a write (eg, master driving the 
+   the NOZ3 signal is asserted on a write (eg, master driving the
    Zorro III bus), DBOE must be negated immediately. */
 
-DBOE		=  slavecyc &  SLAVE & !READ & FCS 
+DBOE		=  slavecyc &  SLAVE & !READ & FCS
 		#  slavecyc &  SLAVE &  READ & FCS & DOE
 		# mastercyc & !SLAVE & !READ & FCS & DOE & !ABOEH & !NOZ3
 		# mastercyc & !SLAVE &  READ & FCS;
@@ -106,11 +106,11 @@ D2Z		=  slavecyc &  READ & FCS &  SLAVE
 Z2D		=   slavecyc & !READ & FCS &  SLAVE
 		#  mastercyc &  READ & FCS & !SLAVE;
 
-/* For either kind of access, data is latched when DTACK is asserted and 
+/* For either kind of access, data is latched when DTACK is asserted and
    we're in data time.  Data is held through the end of the cycle.  */
 
 DBLT		=  slavecyc & FCS & DTACK & DOE &  SLAVE
-		# mastercyc & FCS & DTACK & DOE & !SLAVE 
+		# mastercyc & FCS & DTACK & DOE & !SLAVE
 		#      DBLT & FCS;
 
 /* The address buffer controls.  I want addresses going in unless the SCSI
@@ -128,13 +128,13 @@ ABOEH.D		=  slavecyc
 ABOEH.AR	= NOZ3;
 
 /* The board needs to generate a DTACK here for slave accesses.  Most
-   of the slave terminations are very simple, since they're either 
+   of the slave terminations are very simple, since they're either
    based on a termination signal (SLACK for SCSI, NACK for net or ROM)
    or they're instant (interrupt vector R/W).  During configuration,
-   any write should also be instantly terminated, that would be a 
+   any write should also be instantly terminated, that would be a
    configuration register write (reads are governed by ROM access). */
 
-DTACK		= SLAVE & FCS & DOE & SLACK 
+DTACK		= SLAVE & FCS & DOE & SLACK
 		# SLAVE & FCS & DOE & INTREG
 		# SLAVE & FCS & DOE & INTVEC
 		# SLAVE & FCS & DOE & SID

--- a/source/u207.pld
+++ b/source/u207.pld
@@ -75,7 +75,7 @@ stopcnt		= !FCS
 
 /** OUTPUT TERMS: **/
 
-/* The interrupt process line is generated based on the SCSI interrupt. 
+/* The interrupt process line is generated based on the SCSI interrupt.
    It can only change between Zorro III cycles. */
 
 INT		= !FCS & SINT

--- a/source/u303.pld
+++ b/source/u303.pld
@@ -62,9 +62,9 @@ PIN 22		= !RCHNG	;	/* Registration is changing. */
 
 /** OUTPUT TERMS: **/
 
-/* The SCSI chip can be given the A3090 bus as soon as there's no activity on it. 
+/* The SCSI chip can be given the A3090 bus as soon as there's no activity on it.
    Hold onto it until the SCSI becomes master. */
-/* Not really if granted early the chip will have as asserted then fcs will 
+/* Not really if granted early the chip will have as asserted then fcs will
    assert and when the z bus is granted fcs and addr will assert a the same time */
 
 SBG		= !FCS & !DTACK & !RST & SBR & EBG & !BLOCKBG
@@ -83,7 +83,7 @@ BLOCKBG		= MASTER
 EBR.D		= RCHNG & !EBR & !RST;
 EBR.AR		= RST;
 
-/* A change of registration is necessary whenever a SCSI request comes in 
+/* A change of registration is necessary whenever a SCSI request comes in
    and we're unregistered, or when the MASTER line is dropped and we are
    registered. DMASTER is used to block regd & !master period at beginning*/
 

--- a/source/u304.pld
+++ b/source/u304.pld
@@ -68,7 +68,7 @@ PIN 19		= !SSYNC	;	/* SCSI access synchronizer. */
 
 /** OUTPUT TERMS: **/
 
-/* The SCSI access cycle begins as soon as we have a DOE and at least one 
+/* The SCSI access cycle begins as soon as we have a DOE and at least one
    data strobe.  First thing to do is sync up to this. */
 
 SSYNC.D		= SCSI & DOE & !STERM & DS3 & !MYBUS
@@ -91,10 +91,10 @@ DS.D		= SSYNC & !STERM &  READ
 DS.OE		= SCSI & !MYBUS;
 
 /* The SCSI chip select needs to be set up to the rising edge of the system
-   clock.  So it's gated out with AS and !CLK.  During a DMA, the SCSI chip 
+   clock.  So it's gated out with AS and !CLK.  During a DMA, the SCSI chip
    select is just passed through. */
 
-SREG		=   AS & !MYBUS & !CLK 
+SREG		=   AS & !MYBUS & !CLK
 		#   AS & !MYBUS &  SREG
 		# SCSI &  MYBUS & !CLK;
 
@@ -114,7 +114,7 @@ BA2.OE		= SCSI & !MYBUS;
 
 	DS3	DS2	DS1	DS0	SIZ1	SIZ0	A1	A0
 
-*	 0	 0	 0	 0       
+*	 0	 0	 0	 0
 	 0	 0	 0	 1	 0	 1	1	1
 	 0	 0	 1	 0	 0	 1	1	0
 *	 0	 0	 1	 1
@@ -137,7 +137,7 @@ BA2.OE		= SCSI & !MYBUS;
    it's either byte or longword, trouble if the software does the
    wrong kind of write.
 */
-	
+
 SIZ1		= !DS3 & !DS2 &  DS1 &  DS0
 		# !DS3 &  DS2 &  DS1 & !DS0
 		# !DS3 &  DS2 &  DS1 &  DS0

--- a/source/u305.pld
+++ b/source/u305.pld
@@ -50,7 +50,7 @@ PIN 2		= !MYBUS	;	/* A3090 has the Zorro III bus. */
 PIN 3		= !AS		;	/* SCSI address strobe. */
 PIN 4		=  READ		;	/* The Zorro III read cycle. */
 PIN 5		=  SIZ1		;	/* SCSI transfer size. */
-PIN 6		=  SIZ0		;	
+PIN 6		=  SIZ0		;
 PIN 7		= !NOZ3		;	/* Zorro III bus cutoff */
 PIN 8		= !MTCR		;	/* Zorro III multiple transfer strobe. */
 PIN 10		=  MASTER	;	/* SCSI chip owns A4091 bus. */
@@ -75,12 +75,12 @@ PIN 22		= !DS3		;
 
 /* The buffered FCS depends on the mode.  In non-DMA modes, it's simply
    based on the expansion FCS, as long as a SCSI-chip cycle isn't present
-   (that would indicate DMA awaiting a grant).  In DMA, the expansion 
-   FCS starts a cycle, but it can go away before the A4091 SCSI chip cycle 
+   (that would indicate DMA awaiting a grant).  In DMA, the expansion
+   FCS starts a cycle, but it can go away before the A4091 SCSI chip cycle
    is complete, so a latching term is added. */
 
 
-/* With MASTER, I could interlock differently.  
+/* With MASTER, I could interlock differently.
 
 BFCS		= EFCS & !MASTER & !MYBUS
 		# EFCS &  MASTER &  MYBUS
@@ -110,7 +110,7 @@ DS3		= READ
 
 DS2		= READ
 		# !A1 &               !SIZ0
-		# !A1 &  A0 
+		# !A1 &  A0
 		# !A1 &        SIZ1;
 
 DS1		= READ
@@ -121,7 +121,7 @@ DS1		= READ
 
 DS0		= READ
 		#        A0 &  SIZ1 &  SIZ0
-		#             !SIZ1 & !SIZ0 
+		#             !SIZ1 & !SIZ0
 		#  A1 &  A0
 		#  A1 &        SIZ1;
 

--- a/source/u306.pld
+++ b/source/u306.pld
@@ -77,7 +77,7 @@ PIN 22		= !CYCZ3	;	/* On-bus Zorro III cycle. */
 /** OUTPUT TERMS: **/
 
 /* The Zorro III cycle starts on-bus as soon as it's certain to be a real
-   cycle that's starting.  If just starting, the buffered FCS isn't 
+   cycle that's starting.  If just starting, the buffered FCS isn't
    asserted but ASQ is. Once on, it stays on until a DTACK is properly
    noticed. */
 
@@ -98,7 +98,7 @@ EFCS.OE		= MYBUS & CYCZ3;
 NOZ3		= MYBUS & BFCS & !CYCZ3
 		# RST;
 
-/* The data output enable has to wait until a safe "data phase".  This is 
+/* The data output enable has to wait until a safe "data phase".  This is
    guaranteed to be two clocks after FCS falls.  DCNT is used to time
    this from cycle's start. */
 
@@ -120,8 +120,8 @@ DTSYNC.D	= BFCS & !RST & DOE & BDTACK
 		# BFCS & !RST & DOE & DTSYNC;
 DTSYNC.AR	= !BFCS;
 
-/* The SCSI termination is based on a synchronized DTACK.  I 
-   synchronize DTACK for either slave or master cycle, since the 
+/* The SCSI termination is based on a synchronized DTACK.  I
+   synchronize DTACK for either slave or master cycle, since the
    NCR 53C710 wants the effect of SLACK (which makes a DTACK on slave
    to SCSI cycles) reflected on STERM to actually end the cycle. */
 
@@ -133,7 +133,7 @@ STERM.AR	= !BFCS;
 
 CBACK		= 'b'0;
 CBACK.OE	= 'b'0;
-		
+
 /* We _never_ issue an MTCR, since BURST isn't supported. */
 
 MTCR		= 'b'0;


### PR DESCRIPTION
Add new lines at the end of each file, and remove
extra white space at the end of all lines.